### PR TITLE
Default instructions breaks while doing npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@aws-cdk/assert": "1.91.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.91.0",
+    "aws-cdk": "1.137.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
@@ -25,7 +25,7 @@
     "@aws-cdk/aws-ec2": "^1.95.1",
     "@aws-cdk/aws-lambda": "^1.95.1",
     "@aws-cdk/aws-neptune": "^1.95.1",
-    "@aws-cdk/core": "1.91.0",
+    "@aws-cdk/core": "1.137.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
Fixed as per https://github.com/aws/aws-cdk/issues/18252 . 